### PR TITLE
Merchant destroy

### DIFF
--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -14,8 +14,7 @@ class Api::V1::ItemsController < Api::V1::BaseController
 
   def destroy
     begin
-      item = Item.find(item_params[:id])
-      item.destroy 
+      item = Item.find(item_params[:id]).destroy
     rescue ActiveRecord::RecordNotFound
       render json: {data: nil}
     else

--- a/app/controllers/api/v1/merchants_controller.rb
+++ b/app/controllers/api/v1/merchants_controller.rb
@@ -11,6 +11,16 @@ class Api::V1::MerchantsController < Api::V1::BaseController
     render json: {data: merchant_details( Merchant.find(merchant_params[:id]))}
   end
 
+  def destroy
+    begin
+      merchant = Merchant.find(merchant_params[:id]).destroy
+    rescue ActiveRecord::RecordNotFound
+      render json: {data: nil}
+    else
+      render json: {data: merchant_details(merchant)}
+    end
+  end
+
   private
 
   def merchant_params

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :items, only: [:index, :show, :destroy]
-      resources :merchants, only: [:index, :show]
+      resources :merchants, only: [:index, :show, :destroy]
     end
   end
 end

--- a/spec/requests/api/v1/merchant_spec.rb
+++ b/spec/requests/api/v1/merchant_spec.rb
@@ -41,4 +41,24 @@ describe 'Merchant API' do
     expect(merchant["data"]["attributes"]["name"]).to eq(merchant1.name)
   end
 
+ it 'Can delete a single merchant' do
+    merchant1 = create(:merchant)
+    item1 = merchant1.items.create(attributes_for(:item))
+    merchant1.items.create(attributes_for(:item))
+
+
+    delete "/api/v1/merchants/#{merchant1.id}"
+    expect(response).to be_successful
+    merchant = JSON.parse(response.body)
+
+    expect(merchant["data"]["type"]).to eq("merchant")
+    expect(merchant["data"]["id"]).to eq(merchant1.id.to_s)
+    expect(merchant["data"]["attributes"]["name"]).to eq(merchant1.name)
+
+    delete "/api/v1/merchants/#{Faker::Number.number(digits: 3)}"
+    expect(response).to be_successful
+    merchant = JSON.parse(response.body)
+    expect(merchant["data"]).to eq(nil)
+  end
+
 end


### PR DESCRIPTION
# Destroy Merchant Endpoint
- Closes: #11 
- Responds to `delete /api/v1/merchants/:id`
